### PR TITLE
Use Standard AWS Credential Process

### DIFF
--- a/parquet_tools/commands/csv.py
+++ b/parquet_tools/commands/csv.py
@@ -30,7 +30,6 @@ def configure_parser(paser: ArgumentParser) -> ArgumentParser:
     paser.add_argument('--awsprofile',
                        type=str,
                        required=False,
-                       default='default',
                        help='awscli profile in ~/.aws/credentials. You use this option when you read parquet file on s3.')
     paser.set_defaults(handler=_cli)
     return paser

--- a/parquet_tools/commands/inspect.py
+++ b/parquet_tools/commands/inspect.py
@@ -22,7 +22,6 @@ def configure_parser(paser: ArgumentParser) -> ArgumentParser:
     paser.add_argument('--awsprofile',
                        type=str,
                        required=False,
-                       default='default',
                        help='awscli profile in ~/.aws/credentials. You use this option when you read parquet file on s3.')
 
     paser.set_defaults(handler=_cli)

--- a/parquet_tools/commands/show.py
+++ b/parquet_tools/commands/show.py
@@ -45,7 +45,6 @@ def configure_parser(paser: ArgumentParser) -> ArgumentParser:
     paser.add_argument('--awsprofile',
                        type=str,
                        required=False,
-                       default='default',
                        help='awscli profile in ~/.aws/credentials. You use this option when you read parquet file on s3.')
 
     paser.set_defaults(handler=_cli)

--- a/parquet_tools/commands/utils.py
+++ b/parquet_tools/commands/utils.py
@@ -150,7 +150,7 @@ class S3ParquetFile(ParquetFile):
                 yield localfile
 
 
-def get_aws_session(profile_name: str='default') -> boto3.Session:
+def get_aws_session(profile_name: Optional[str]) -> boto3.Session:
     return boto3.Session(profile_name=profile_name)
 
 
@@ -158,7 +158,7 @@ def _is_s3_file(filename: str) -> bool:
     return filename[:5] == 's3://'
 
 
-def to_parquet_file(file_exp: str, awsprofile: str) -> ParquetFile:
+def to_parquet_file(file_exp: str, awsprofile: Optional[str]) -> ParquetFile:
     '''Transform file_exp to ParquetFile object.
     '''
     if _is_s3_file(file_exp):

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -36,7 +36,7 @@ def parquet_file():
             'columns': [],
             'file': ['file1.parquet'],
             'head': -1,
-            'awsprofile': 'default'
+            'awsprofile': None
         }
     ),
     # most complex one

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -22,7 +22,7 @@ def parser():
             'file': ['file1.parquet'],
             'format': 'psql',
             'head': -1,
-            'awsprofile': 'default'
+            'awsprofile': None
         }
     ),
     # most complex one
@@ -33,7 +33,7 @@ def parser():
             'file': ['file1.parquet', 'file2.parquet'],
             'format': 'github',
             'head': 100,
-            'awsprofile': 'default'
+            'awsprofile': None
         }
     ),
     # file is on S3


### PR DESCRIPTION
Since there is *always* an `awsprofile` name passed, either the one from the command line or `'default'`, it is impossible to use environment variables like `AWS_PROFILE`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` etc. because it instructs boto3 to always look for a named profile.

By making the profile name optional, we keep the same external behavior (since the default profile name is `default` as well and chosen if none of the above is given), but enable us to use the standard credential process of boto(core).

https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html