### PR TITLE
Add license file

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Kentaro Ueda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 repository = "https://github.com/ktrueda/parquet-tools"
 homepage = "https://github.com/ktrueda/parquet-tools"
 keywords = ["parquet-tools", "parquet"]
+exclude = ["parquet_tools/parquet.thrift", "parquet_tools/README.md"]
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
This PR addresses the issues in #15 

* Poetry [automatically includes the license file](https://github.com/python-poetry/poetry/issues/836#issuecomment-457589268) in the source tarball
* It's my understanding that `parquet.thrift` is only required to generate the Python files. By removing it from the source code tarball, it's no longer required to include the Apache license file

Related to https://github.com/conda-forge/staged-recipes/pull/15926