### PR TITLE
Show schema meta

### DIFF
--- a/parquet_tools/commands/inspect.py
+++ b/parquet_tools/commands/inspect.py
@@ -62,7 +62,6 @@ def _execute_simple(filename: str) -> None:
     file_schema_meta: dict = pq_file.schema_arrow.metadata
     print(_simple_schema_meta_expression(file_schema_meta))
 
-
 def _simple_meta_expression(file_meta: pq.FileMetaData) -> str:
     return dedent(f'''
     ############ file meta data ############

--- a/parquet_tools/commands/inspect.py
+++ b/parquet_tools/commands/inspect.py
@@ -62,6 +62,7 @@ def _execute_simple(filename: str) -> None:
     file_schema_meta: dict = pq_file.schema_arrow.metadata
     print(_simple_schema_meta_expression(file_schema_meta))
 
+
 def _simple_meta_expression(file_meta: pq.FileMetaData) -> str:
     return dedent(f'''
     ############ file meta data ############

--- a/parquet_tools/commands/inspect.py
+++ b/parquet_tools/commands/inspect.py
@@ -59,8 +59,7 @@ def _execute_simple(filename: str) -> None:
     print(_simple_meta_expression(file_meta))
     file_schema: pq.ParquetSchema = pq_file.schema
     print(_simple_schema_expression(file_schema))
-    file_schema_meta: dict = pq_file.schema_arrow.metadata
-    print(_simple_schema_meta_expression(file_schema_meta))
+
 
 def _simple_meta_expression(file_meta: pq.FileMetaData) -> str:
     return dedent(f'''
@@ -96,19 +95,6 @@ def _simple_schema_expression(schema) -> str:
         ''')
 
     return exp
-
-
-def _simple_schema_meta_expression(schema_meta) -> str:
-    exp = dedent(f'''
-    ############ file schema meta data ############
-    ''')
-    decoded_schema_meta = ""
-    for key, value in schema_meta.items():
-        decoded_schema_meta += f'''
-        {key.decode("utf-8")}: {value.decode("utf-8")}
-        '''
-
-    return exp + dedent(decoded_schema_meta)
 
 
 def _execute_detail(filename: str) -> None:

--- a/parquet_tools/commands/inspect.py
+++ b/parquet_tools/commands/inspect.py
@@ -114,7 +114,7 @@ def _obj_to_string(obj, toatty: bool, level: int = 1) -> str:
         extra += color[i % 4] + '■■■■' + Style.RESET_ALL if toatty else '    '
     ret = ''
     if isinstance(obj, str) or isinstance(obj, int) or isinstance(obj, bytes):
-        ret += str(obj)[:50]
+        ret += str(obj)
     else:
         ret += str(obj.__class__.__name__)
         ret += '\n'

--- a/parquet_tools/commands/inspect.py
+++ b/parquet_tools/commands/inspect.py
@@ -59,7 +59,8 @@ def _execute_simple(filename: str) -> None:
     print(_simple_meta_expression(file_meta))
     file_schema: pq.ParquetSchema = pq_file.schema
     print(_simple_schema_expression(file_schema))
-
+    file_schema_meta: dict = pq_file.schema_arrow.metadata
+    print(_simple_schema_meta_expression(file_schema_meta))
 
 def _simple_meta_expression(file_meta: pq.FileMetaData) -> str:
     return dedent(f'''
@@ -95,6 +96,19 @@ def _simple_schema_expression(schema) -> str:
         ''')
 
     return exp
+
+
+def _simple_schema_meta_expression(schema_meta) -> str:
+    exp = dedent(f'''
+    ############ file schema meta data ############
+    ''')
+    decoded_schema_meta = ""
+    for key, value in schema_meta.items():
+        decoded_schema_meta += f'''
+        {key.decode("utf-8")}: {value.decode("utf-8")}
+        '''
+
+    return exp + dedent(decoded_schema_meta)
 
 
 def _execute_detail(filename: str) -> None:


### PR DESCRIPTION
Would it be possible to add a possibility to see schema's metadata upon using `inspect` on it?

I have a use case where I specify comments and notes on files by inserting arbitrary keys values into the metadata of the file like so
```
import pyarrow as pa
import pyarrow.parquet as pq
 
schema = pa.schema([
        pa.field('A', pa.string()),
        pa.field('B', pa.int64())
    ],
    metadata={"comment": "very important file"})

with pq.ParquetWriter("test.parquet", schema) as writer:
    table = pa.Table.from_arrays([["a"], [1]], schema=schema)
    writer.write_table(table)
```
Afterwards I can read the comments using 
```
pg_file = pq.read_table("test.parquet")
print(pg_file.schema.metadata)
```
Output:
```
{b'comment': b'very important file'}
```

I would like to be able to access this information also from the command line. Having found this wonderful repo I wondered if I can simply solve my problem by contributing to it. The code I added just tries to print this specific part of the metadata. 

I am not an expert on parquet and it might be very well true that there is a better way to access this data. Please let me know of any problems with the current solution.