### PR TITLE
Allow pandas 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ exclude = ["parquet_tools/parquet.thrift", "parquet_tools/README.md"]
 python = "^3.8"
 halo = "^0.0.29"
 pyarrow = "*"
-pandas = "^1"
+pandas = ">=1"
 tabulate = "^0.8.7"
 boto3 = "^1.13"
 thrift = "^0.13.0"


### PR DESCRIPTION
Update pandas requirement to support pandas 2.0+. AFAICT this works with pandas 2.0. Right now I get the pip error:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
parquet-tools 0.2.13 requires pandas<2,>=1, but you have pandas 2.0.1 which is incompatible.
```